### PR TITLE
CHECKPASS-267 design: [Client] 간이 수강 신청 시스템 UI 구현

### DIFF
--- a/frontend/src/Pages/Enrollment/EnrollmentPage.tsx
+++ b/frontend/src/Pages/Enrollment/EnrollmentPage.tsx
@@ -1,0 +1,257 @@
+import styled from 'styled-components';
+import { colors, fontSizes } from '../../Styles/theme';
+
+interface TableDataProps {
+  flex?: number;
+}
+
+const EnrollmentPage = () => {
+  return (
+    <Container>
+      <Header>
+        <Logo>CHECK PASS</Logo>
+        <LogoutButton>로그아웃</LogoutButton>
+      </Header>
+      <Main>
+        <Section>
+          <TextContent>
+            <Title>개설 강의 목록</Title>
+          </TextContent>
+          <SearchContainer></SearchContainer>
+        </Section>
+        <Section>
+          <LectureList>
+            <TableHead>
+              <TableRow>
+                <TableHeader flex={0.2}></TableHeader>
+                <TableHeader>수강 신청</TableHeader>
+                <TableHeader>강의번호</TableHeader>
+                <TableHeader>분반</TableHeader>
+                <TableHeader flex={1}>강의명</TableHeader>
+                <TableHeader>학년</TableHeader>
+                <TableHeader>정원</TableHeader>
+                <TableHeader>수강 인원</TableHeader>
+                <TableHeader>교수명</TableHeader>
+                <TableHeader>학점</TableHeader>
+                <TableHeader flex={1}>강의실</TableHeader>
+                <TableHeader flex={1.2}>강의 시간</TableHeader>
+                <TableHeader>이수 구분</TableHeader>
+                <TableHeader>주/야 구분</TableHeader>
+                <TableHeader>강의 계획서</TableHeader>
+              </TableRow>
+            </TableHead>
+            <tbody>
+              <TableRow>
+                <TableData flex={0.2}>1</TableData>
+                <TableData>
+                  <button>삭제</button>
+                </TableData>
+                <TableData>0123456</TableData>
+                <TableHeader>1</TableHeader>
+                <TableData flex={1}>웹 프로그래밍</TableData>
+                <TableData>2</TableData>
+                <TableData>30</TableData>
+                <TableData>18</TableData>
+                <TableData>이광</TableData>
+                <TableData>3</TableData>
+                <TableData flex={1}>미래융합정보관(225)</TableData>
+                <TableData flex={1.2}>화(1A,1B,2A,2B)</TableData>
+                <TableData>전선</TableData>
+                <TableData>주간</TableData>
+                <TableData>
+                  <button>강의 계획서</button>
+                </TableData>
+              </TableRow>
+            </tbody>
+          </LectureList>
+        </Section>
+        <Section>
+          <TextContent>
+            <Title>
+              <span>수강 신청 내역 </span>
+            </Title>
+            <Detalis>
+              <span>총 신청 가능 학점 20 | </span>
+              <span>신청 강의 수 1 | </span>
+              <span>신청 학점 3</span>
+            </Detalis>
+          </TextContent>
+          <RegisterList>
+            <TableHead>
+              <TableRow>
+                <TableHeader flex={0.2}></TableHeader>
+                <TableHeader>수강 신청</TableHeader>
+                <TableHeader>강의번호</TableHeader>
+                <TableHeader>분반</TableHeader>
+                <TableHeader flex={1}>강의명</TableHeader>
+                <TableHeader>학년</TableHeader>
+                <TableHeader>정원</TableHeader>
+                <TableHeader>수강 인원</TableHeader>
+                <TableHeader>교수명</TableHeader>
+                <TableHeader>학점</TableHeader>
+                <TableHeader flex={1}>강의실</TableHeader>
+                <TableHeader flex={1.2}>강의 시간</TableHeader>
+                <TableHeader>이수 구분</TableHeader>
+                <TableHeader>주/야 구분</TableHeader>
+                <TableHeader>강의 계획서</TableHeader>
+              </TableRow>
+            </TableHead>
+            <tbody>
+              <TableRow>
+                <TableData flex={0.2}>1</TableData>
+                <TableData>
+                  <button>삭제</button>
+                </TableData>
+                <TableData>0123456</TableData>
+                <TableHeader>1</TableHeader>
+                <TableData flex={1}>웹 프로그래밍</TableData>
+                <TableData>2</TableData>
+                <TableData>30</TableData>
+                <TableData>18</TableData>
+                <TableData>이광</TableData>
+                <TableData>3</TableData>
+                <TableData flex={1}>미래융합정보관(225)</TableData>
+                <TableData flex={1.2}>화(1A,1B,2A,2B)</TableData>
+                <TableData>전선</TableData>
+                <TableData>주간</TableData>
+                <TableData>
+                  <button>강의 계획서</button>
+                </TableData>
+              </TableRow>
+            </tbody>
+          </RegisterList>
+        </Section>
+      </Main>
+    </Container>
+  );
+};
+
+export default EnrollmentPage;
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 70px;
+  padding: 35px;
+
+  border-bottom: 1.5px solid ${colors['border-default']};
+`;
+
+const Logo = styled.div`
+  font-family: 'AppleTea';
+  font-size: ${fontSizes['header-logo']};
+
+  color: ${colors['text-primary']};
+`;
+
+const LogoutButton = styled.button`
+  padding: 5px;
+
+  border: 1px solid #4f4f4f;
+  border-radius: 10px;
+
+  cursor: pointer;
+`;
+
+const Main = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 20px;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+
+  padding-bottom: 20px;
+`;
+
+const SearchContainer = styled.div`
+  width: 98%;
+  height: 120px;
+
+  border: 1px solid #000;
+`;
+
+const LectureList = styled.table`
+  width: 98%;
+  height: 500px;
+
+  overflow: auto;
+  font-size: 0.9em;
+
+  border: 1px solid #a39485;
+  border-collapse: collapse;
+`;
+
+const TextContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  width: 98%;
+  padding-bottom: 10px;
+`;
+
+const Detalis = styled.div``;
+
+const Title = styled.div`
+  font-size: 18px;
+  font-weight: 900;
+`;
+
+const RegisterList = styled.table`
+  width: 98%;
+
+  overflow: hidden;
+  font-size: 0.9em;
+
+  border: 1px solid #a39485;
+  border-collapse: collapse;
+`;
+
+const TableHead = styled.thead`
+  background: #edf3ff;
+`;
+
+const TableRow = styled.tr`
+  display: flex;
+`;
+
+const TableData = styled.td<TableDataProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: ${(props) => props.flex || 0.4};
+
+  padding: 0.8rem 0.3rem;
+  text-align: center;
+
+  background: #fff;
+  border-bottom: 1px solid #a39485;
+`;
+
+const TableHeader = styled.th<TableDataProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: ${(props) => props.flex || 0.4};
+
+  padding: 0.8rem 0.3rem;
+  border-bottom: 1px solid #a39485;
+`;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import FindPwPage from './Pages/Login/FindPwPage';
 import CheckEmailPage from './Pages/Login/CheckEmailPage';
 import AttendancePage from './Pages/Main/AttendancePage';
 import LecturePage from './Pages/Main/LecturePage/LecturePage';
+import EnrollmentPage from './Pages/Enrollment/EnrollmentPage';
 
 const router = createBrowserRouter([
   {
@@ -45,6 +46,10 @@ const router = createBrowserRouter([
   {
     path: '/lecture',
     element: <LecturePage />,
+  },
+  {
+    path: '/enrollment',
+    element: <EnrollmentPage />,
   },
 ]);
 


### PR DESCRIPTION
## 🚀 구현 목록 (CHECKPASS-267)
 
- [x] Header
  - 헤더의 좌측에는 서비스 로고, 우측에는 로그아웃 버튼을 배치한다.
- [ ] 세부 검색 필터 
  - 보류 (개발하더라도 강의 이름이 1순위, 그 외의 것들은 출석 기능 개발 후로 미룸)
- [x] 개설 강의 목록 
  - 수강 신청 버튼, 강의 계획서 버튼
  - 강의 번호, 분반, 강의명, 교수명
  - 학년, 학점
  - 정원, 수강 인원
  - 강의실, 강의 시간
  - 이수 구분, 주/야 구분
- [x] 수강 신청 목록

## 🔨 추후 수정되어야 할 부분

- 수강 신청 기능만 간략하게 구현하기 위해 개설된 강의 목록 전체만을 보여 주고, 구체적인 검색 필터 UI는 구현되어 있지 않습니다. 
- 검색 필터 구현은 간이 수강 신청 시스템에서 2순위로 보류될 예정 (우선 순위 1 수강 신청, 우선 순위 2 강의 관리 시스템 구현)