### PR TITLE
CHECKPASS-292 fix: [Client] 수강 신청 내역 요청 객체 인덱스 삭제

### DIFF
--- a/frontend/src/Pages/Enrollment/EnrollmentPage.tsx
+++ b/frontend/src/Pages/Enrollment/EnrollmentPage.tsx
@@ -62,7 +62,7 @@ const EnrollmentPage = () => {
   const enrollmentLecture = async () => {
     try {
       const response = await axios.get(`http://localhost:8080/enrollment`);
-      const resultSet = response.data.resultSet['2024년도 1학기'];
+      const resultSet = response.data.resultSet;
 
       let score = 0;
 


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 학생 수강 신청 내역을 요청으로 받는 과정에서 잘못된 인덱스 사용이 존재해 정상적으로 수강 내역이 나타나고 있지 않습니다.

## 🔨 TO-BE

- [x] 수강 신청 내역 데이터 형식을 수정한다.