### PR TITLE
CHECKPASS-293 feat: [Client] 메인 페이지 카드 Link 추가

### DIFF
--- a/frontend/src/Pages/Main/MainPage.tsx
+++ b/frontend/src/Pages/Main/MainPage.tsx
@@ -1,4 +1,5 @@
 import styled, { ThemeProvider } from 'styled-components';
+import { Link } from 'react-router-dom';
 import { MainTheme, fontSizes } from '../../Styles/theme';
 import Header from '../../components/Header';
 import { IMAGE } from '../../constants/image';
@@ -23,31 +24,38 @@ const MainPage = () => {
             </GreetingMessage>
           </Greeting>
           <Wrapper>
-            <Card
-              width={'37.5rem'}
-              height={'31.6rem'}
-              image={IMAGE.BeaconIcon}
-              description="BeaconIcon"
-              content="메인 서비스"
-              title="빠르고 편리하게 출석하기"
-              hashtag="#빠르고편리한출결 #beacon #전자출결"
-            >
-              {isDarkMode ? (
-                <BeaconImage src={IMAGE.DarkBeaconImage} alt="BecaconImage" />
-              ) : (
-                <BeaconImage src={IMAGE.LightBeaconImage} alt="BecaconImage" />
-              )}
-            </Card>
+            <Link to="/attendance">
+              <Card
+                width={'37.5rem'}
+                height={'31.6rem'}
+                image={IMAGE.BeaconIcon}
+                description="BeaconIcon"
+                content="메인 서비스"
+                title="빠르고 편리하게 출석하기"
+                hashtag="#빠르고편리한출결 #beacon #전자출결"
+              >
+                {isDarkMode ? (
+                  <BeaconImage src={IMAGE.DarkBeaconImage} alt="BecaconImage" />
+                ) : (
+                  <BeaconImage
+                    src={IMAGE.LightBeaconImage}
+                    alt="BecaconImage"
+                  />
+                )}
+              </Card>
+            </Link>
             <Cards>
               {CARD_DATA.map((data, index) => (
-                <Card
-                  key={index}
-                  image={data.image}
-                  description={data.description}
-                  content={data.content}
-                  title={data.title}
-                  hashtag={data.hashtag}
-                />
+                <Link to={data.link}>
+                  <Card
+                    key={index}
+                    image={data.image}
+                    description={data.description}
+                    content={data.content}
+                    title={data.title}
+                    hashtag={data.hashtag}
+                  />
+                </Link>
               ))}
             </Cards>
           </Wrapper>
@@ -103,7 +111,7 @@ const GreetingMessage = styled.div`
 
 const Wrapper = styled.div`
   display: flex;
-  gap: 30px;
+  gap: 26px;
 `;
 
 const BeaconImage = styled.img`

--- a/frontend/src/components/Card/Card.tsx
+++ b/frontend/src/components/Card/Card.tsx
@@ -51,9 +51,11 @@ const CardContainer = styled.div<CardstyleProps>`
 
   gap: 18px;
 
+  color: ${({ theme }) => theme.color};
   background-color: ${({ theme }) => theme.itemColor};
-  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.1);
+
   border-radius: 16px;
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.1);
 
   transition: margin 0.3s;
 

--- a/frontend/src/constants/cardData.ts
+++ b/frontend/src/constants/cardData.ts
@@ -7,13 +7,15 @@ const CARD_DATA = Object.freeze([
     content: '수강 신청',
     title: '수강 신청 바로 가기',
     hashtag: '#개설강의목록 #수강신청내역',
+    link: '/enrollment',
   },
   {
     image: IMAGE.CalendarIcon,
     description: 'CalendarIcon',
-    content: '비콘이 이상하다면?',
+    content: '학기 시간표가 궁금하다면?',
     title: '시간표 확인하기',
     hashtag: '#학기시간표 #강의확인',
+    link: '/lecture',
   },
   {
     image: IMAGE.CommunityIcon,
@@ -21,6 +23,7 @@ const CARD_DATA = Object.freeze([
     content: '수강생 의견',
     title: '자유롭게 소통하기',
     hashtag: '#의견 #소통 #정보공유',
+    link: '/',
   },
   {
     image: IMAGE.NoticeIcon,
@@ -28,6 +31,7 @@ const CARD_DATA = Object.freeze([
     content: '과제가 궁금하다면?',
     title: '공지 확인하기',
     hashtag: '#일정 #과제 #공지',
+    link: '/',
   },
 ]);
 


### PR DESCRIPTION
## 🔎 AS-IS

- 현재 메인 페이지의 콘텐츠 카드를 선택했을 때 아무런 이벤트도 일어나고 있지 않습니다. 따라서 콘텐츠 카드에 해당하는 페이지가 나타날 수 있도록 Link 태그 추가가 필요합니다.

## ✨ TO-BE

- [x] CardData 배열 내 객채에 URL을 저장할 `link` key를 추가하고, value에 카드들이 이동할 페이지의 `URL`을 작성한다.
- [x] 메인 페이지의 Card 태그에 Link를 추가한다.