### PR TITLE
CHECKPASS-339 feat: [Client] 선택한 개설 강의 수강 중인 모든 학생 이름 표시

### DIFF
--- a/frontend/src/Pages/Main/AttendancePage/handlers.ts
+++ b/frontend/src/Pages/Main/AttendancePage/handlers.ts
@@ -1,0 +1,20 @@
+import { SetStateAction } from 'react';
+
+// 강의별 분반 조회
+const handleDivisionChange = (
+  e: React.ChangeEvent<HTMLSelectElement>,
+  setSelectedDivision: (value: SetStateAction<string>) => void
+) => {
+  setSelectedDivision(e.target.value);
+};
+
+// 강의/분반별 주차 조회
+const handleWeekChange = (
+  e: React.ChangeEvent<HTMLSelectElement>,
+  setSelectedWeek: (value: SetStateAction<string>) => void
+) => {
+  const week = e.target.value;
+  if (week !== '--주차 선택--') setSelectedWeek(week);
+};
+
+export { handleDivisionChange, handleWeekChange };

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,7 +6,7 @@ import SignUpStudent from './Pages/Login/SignUp/SignUpStudent';
 import SignUpProfStaff from './Pages/Login/SignUp/SignUpProfStaff';
 import FindPwPage from './Pages/Login/FindPwPage';
 import CheckEmailPage from './Pages/Login/CheckEmailPage';
-import AttendancePage from './Pages/Main/AttendancePage';
+import AttendancePage from './Pages/Main/AttendancePage/AttendancePage';
 import LecturePage from './Pages/Main/LecturePage/LecturePage';
 import EnrollmentPage from './Pages/Enrollment/EnrollmentPage';
 import UserPage from './Pages/Main/UserPage';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,6 +19,16 @@ type ProfessorLectures = {
   division: string;
 };
 
+type LectureByCode = {
+  lectureCode: string;
+  divisions: string[];
+};
+
+type ProfessorLecture = {
+  lectureCode: string;
+  lecturesByCode: LectureByCode[];
+};
+
 type LectureInfo = {
   lectureName: string;
   professorName: string;
@@ -37,4 +47,4 @@ type TableProps = {
   buttonHandler: (lectureCode: number) => void;
 };
 
-export type { Lecture, ProfessorLectures, LectureInfo, TableProps };
+export type { Lecture, ProfessorLectures, ProfessorLecture, LectureInfo, TableProps };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,6 +13,12 @@ type Lecture = {
   dayOrNight: 'day' | 'night';
 };
 
+type ProfessorLectures = {
+  lectureName: string;
+  lectureCode: number;
+  division: string;
+};
+
 type LectureInfo = {
   lectureName: string;
   professorName: string;
@@ -31,4 +37,4 @@ type TableProps = {
   buttonHandler: (lectureCode: number) => void;
 };
 
-export type { Lecture, LectureInfo, TableProps };
+export type { Lecture, ProfessorLectures, LectureInfo, TableProps };

--- a/frontend/src/utils/groupLectureUtils.ts
+++ b/frontend/src/utils/groupLectureUtils.ts
@@ -1,0 +1,48 @@
+import { ProfessorLectures } from '@/src/types';
+
+// 강의 정보를 이름별로 그룹화하는 함수
+const groupByName = (professorLectures: ProfessorLectures[]) => {
+  const lecturesByName = new Map<string, ProfessorLectures[]>();
+
+  professorLectures.forEach((lecture) => {
+    const existingGroup = lecturesByName.get(lecture.lectureName) || [];
+
+    existingGroup.push(lecture);
+    lecturesByName.set(lecture.lectureName, existingGroup);
+  });
+
+  return lecturesByName;
+};
+
+// 강의 코드별로 분반 정보를 그룹화하는 함수
+const groupByCode = (lectures: ProfessorLectures[]) => {
+  const lecturesByCodeMap: Map<number, string[]> = new Map();
+
+  lectures.forEach((lecture) => {
+    const divisions = lecturesByCodeMap.get(lecture.lectureCode) || [];
+
+    divisions.push(lecture.division);
+    lecturesByCodeMap.set(lecture.lectureCode, divisions);
+  });
+
+  const lecturesByCode = Array.from(lecturesByCodeMap).map(([lectureCode, divisions]) => ({
+    lectureCode,
+    divisions,
+  }));
+
+  return lecturesByCode;
+};
+
+// 강의 정보 처리 함수
+const groupLectures = (professorLectures: ProfessorLectures[]) => {
+  const lecturesByName = groupByName(professorLectures);
+
+  const groupedLectures = Array.from(lecturesByName).map(([lectureName, lectures]) => ({
+    lectureName,
+    lecturesByCode: groupByCode(lectures),
+  }));
+
+  return groupedLectures;
+};
+
+export default groupLectures;


### PR DESCRIPTION
## ✨ TO-BE
- [x] 교수가 특정 강의를 선택하면 선택된 강의에 대응하는 분반 및 주차 SELECT 태그가 나타난다.
- [x] 분반 및 주차를 선택하면 선택된 항목에 대응하는 모든 학생의 이름이 나타난다.
  - [x] 이때, 선택된 강의의 정원 또한 업데이트된다.

## 🔎 구현 화면

### 강의 선택 SELECT
<img width="1470" alt="스크린샷 2024-03-23 오전 3 53 23" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/e45f1ed0-19da-45f7-af51-4f685bb26e0b">

### 강의 선택 시 강의에 대응하는 분반 및 주차 SELECT 태그 표시
<img width="1470" alt="스크린샷 2024-03-23 오전 3 55 04" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/86a2e217-df5a-4aab-9832-f0a88ae78701">

<img width="1470" alt="스크린샷 2024-03-23 오전 3 55 23" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/7ce614ff-b1d1-4a09-a6a5-2175a2bfac34">

<img width="1470" alt="스크린샷 2024-03-23 오전 3 55 53" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/c0310f01-378d-45e6-ab35-f3ebcbb37c5d">

### 모든 조건 설정 시 선택된 조건에 대응하는 학생 목록 표시

<img width="1470" alt="스크린샷 2024-03-23 오전 3 56 32" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/18e6761a-2a8b-486e-87dd-8f0ef653b3a9">

<img width="1470" alt="스크린샷 2024-03-23 오전 3 56 43" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/4cf15b5c-840d-4c01-8863-49d5edcb8fdd">

<img width="1470" alt="스크린샷 2024-03-23 오전 3 56 55" src="https://github.com/FX-PR0JECT/CHECKPASS-CLIENT/assets/106158901/520709e3-2802-4980-b259-14b105f06013">
